### PR TITLE
Made it call jekyll post_write hook

### DIFF
--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -51,6 +51,7 @@ module Jekyll
     def write(dest)
       dest_path = destination(dest)
       output_html(dest_path, output)
+      trigger_hooks(:post_write)
     end
   end
 
@@ -64,6 +65,7 @@ module Jekyll
       else
         output_html(dest_path, output)
       end
+      Jekyll::Hooks.trigger hook_owner, :post_write, self
     end
   end
 


### PR DESCRIPTION
The current version doesn't support the post_write jekyll hook, fired after post is written to disk, which can break other plugins that rely on this hook.

I put these calls in. The two lines of code are directly from Jekyll, tested on jekyll 3.3.1.

Enjoy.
