### PR TITLE
Exlusion fix

### DIFF
--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -5,21 +5,8 @@ require 'cssminify2'
 module Jekyll
   module Compressor
     def exclude?(dest, dest_path)
-      res = false
       file_name = dest_path.slice(dest.length+1..dest_path.length)
-      exclude = @site.config['jekyll-minifier'] && @site.config['jekyll-minifier']['exclude']
-      if exclude
-        if exclude.is_a? String
-          exclude = [exclude]
-        end
-        exclude.each do |e|
-          if e == file_name || File.fnmatch(e, file_name)
-            res = true
-            break
-          end
-        end
-      end
-      res
+      exclude.any? { |e| e == file_name || File.fnmatch(e, file_name) }
     end
 
     def output_file(dest, content)
@@ -74,6 +61,12 @@ module Jekyll
     def output_css(path, content)
       compressor = CSSminify2.new
       output_file(path, compressor.compress(content))
+    end
+
+    private
+
+    def exclude
+      @exclude ||= Array(@site.config['jekyll-minifier'].dig('exclude'))
     end
   end
 

--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -4,11 +4,6 @@ require 'cssminify2'
 
 module Jekyll
   module Compressor
-    def exclude?(dest, dest_path)
-      file_name = dest_path.slice(dest.length+1..dest_path.length)
-      exclude.any? { |e| e == file_name || File.fnmatch(e, file_name) }
-    end
-
     def output_file(dest, content)
       FileUtils.mkdir_p(File.dirname(dest))
       File.open(dest, 'w') do |f|
@@ -64,6 +59,11 @@ module Jekyll
     end
 
     private
+
+    def exclude?(dest, dest_path)
+      file_name = dest_path.slice(dest.length+1..dest_path.length)
+      exclude.any? { |e| e == file_name || File.fnmatch(e, file_name) }
+    end
 
     def exclude
       @exclude ||= Array(@site.config['jekyll-minifier'].dig('exclude'))

--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -37,28 +37,25 @@ module Jekyll
       opts = @site.config['jekyll-minifier']
 
       if ( !opts.nil? )
-        # Convert keys to symboles
-        opts.keys.each { |key| opts[(key.to_sym rescue key) || key] = opts.delete(key) }
-
-        args[:remove_spaces_inside_tags]   = opts[:remove_spaces_inside_tags]  if opts.has_key?(:remove_spaces_inside_tags)
-        args[:remove_multi_spaces]         = opts[:remove_multi_spaces]        if opts.has_key?(:remove_multi_spaces)
-        args[:remove_comments]             = opts[:remove_comments]            if opts.has_key?(:remove_comments)
-        args[:remove_intertag_spaces]      = opts[:remove_intertag_spaces]     if opts.has_key?(:remove_intertag_spaces)
-        args[:remove_quotes]               = opts[:remove_quotes]              if opts.has_key?(:remove_quotes)
-        args[:compress_css]                = opts[:compress_css]               if opts.has_key?(:compress_css)
-        args[:compress_javascript]         = opts[:compress_javascript]        if opts.has_key?(:compress_javascript)
-        args[:simple_doctype]              = opts[:simple_doctype]             if opts.has_key?(:simple_doctype)
-        args[:remove_script_attributes]    = opts[:remove_script_attributes]   if opts.has_key?(:remove_script_attributes)
-        args[:remove_style_attributes]     = opts[:remove_style_attributes]    if opts.has_key?(:remove_style_attributes)
-        args[:remove_link_attributes]      = opts[:remove_link_attributes]     if opts.has_key?(:remove_link_attributes)
-        args[:remove_form_attributes]      = opts[:remove_form_attributes]     if opts.has_key?(:remove_form_attributes)
-        args[:remove_input_attributes]     = opts[:remove_input_attributes]    if opts.has_key?(:remove_input_attributes)
-        args[:remove_javascript_protocol]  = opts[:remove_javascript_protocol] if opts.has_key?(:remove_javascript_protocol)
-        args[:remove_http_protocol]        = opts[:remove_http_protocol]       if opts.has_key?(:remove_http_protocol)
-        args[:remove_https_protocol]       = opts[:remove_https_protocol]      if opts.has_key?(:remove_https_protocol)
-        args[:preserve_line_breaks]        = opts[:preserve_line_breaks]       if opts.has_key?(:preserve_line_breaks)
-        args[:simple_boolean_attributes]   = opts[:simple_boolean_attributes]  if opts.has_key?(:simple_boolean_attributes)
-        args[:compress_js_templates]       = opts[:compress_js_templates]      if opts.has_key?(:compress_js_templates)
+        args[:remove_spaces_inside_tags]   = opts['remove_spaces_inside_tags']  if opts.has_key?('remove_spaces_inside_tags')
+        args[:remove_multi_spaces]         = opts['remove_multi_spaces']        if opts.has_key?('remove_multi_spaces')
+        args[:remove_comments]             = opts['remove_comments']            if opts.has_key?('remove_comments')
+        args[:remove_intertag_spaces]      = opts['remove_intertag_spaces']     if opts.has_key?('remove_intertag_spaces')
+        args[:remove_quotes]               = opts['remove_quotes']              if opts.has_key?('remove_quotes')
+        args[:compress_css]                = opts['compress_css']               if opts.has_key?('compress_css')
+        args[:compress_javascript]         = opts['compress_javascript']        if opts.has_key?('compress_javascript')
+        args[:simple_doctype]              = opts['simple_doctype']             if opts.has_key?('simple_doctype')
+        args[:remove_script_attributes]    = opts['remove_script_attributes']   if opts.has_key?('remove_script_attributes')
+        args[:remove_style_attributes]     = opts['remove_style_attributes']    if opts.has_key?('remove_style_attributes')
+        args[:remove_link_attributes]      = opts['remove_link_attributes']     if opts.has_key?('remove_link_attributes')
+        args[:remove_form_attributes]      = opts['remove_form_attributes']     if opts.has_key?('remove_form_attributes')
+        args[:remove_input_attributes]     = opts['remove_input_attributes']    if opts.has_key?('remove_input_attributes')
+        args[:remove_javascript_protocol]  = opts['remove_javascript_protocol'] if opts.has_key?('remove_javascript_protocol')
+        args[:remove_http_protocol]        = opts['remove_http_protocol']       if opts.has_key?('remove_http_protocol')
+        args[:remove_https_protocol]       = opts['remove_https_protocol']      if opts.has_key?('remove_https_protocol')
+        args[:preserve_line_breaks]        = opts['preserve_line_breaks']       if opts.has_key?('preserve_line_breaks')
+        args[:simple_boolean_attributes]   = opts['simple_boolean_attributes']  if opts.has_key?('simple_boolean_attributes')
+        args[:compress_js_templates]       = opts['compress_js_templates']      if opts.has_key?('compress_js_templates')
         args[:preserve_patterns]          += [/<\?php.*?\?>/im]                if opts[:preserve_php] == true
 
         # Potential to add patterns from YAML


### PR DESCRIPTION
This fixes persistent issues with excluding files.  In essence, the coercion from string keys to symbol keys in `output_html` violated idempotency; i.e. the first attempt to get the `exclude` setting would work via a string, but then failed in subsequent attempts, since a symbol would be required.  This pull request just uses string keys throughout.

I also greatly simplified how exclusion checking works by making use of `Kernel#Array`, `Array#any?`, and `Hash#dig`.