### PR TITLE
Improve performance by not generating newlines in CSS

### DIFF
--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -135,7 +135,7 @@ module Jekyll
         end
         if ( compress )
           compressor = CSSminify2.new()
-          output_file(path, compressor.compress(content))
+          output_file(path, compressor.compress(content, linebreakpos: 0))
         else
           output_file(path, content)
         end


### PR DESCRIPTION
While investigating why my blog takes so long to build, I found this arcane line breaking mechanism, which is both slow and unnecessary. It can be made faster, see https://github.com/digitalsparky/cssminify/pull/5. However, the best way to improve performance is to simply remove this feature. I don't entirely understand why it was necessary (the library is from 2012, maybe back then people used weird source control software that could not handle that, but `git` has no such issues), but anyways the files generated here are not added to VCS but instead served over the internet, where it should not matter.

PS: I have not actually tested whether this works, since I don't know Ruby. Please test before merging (or alternatively send me a link or something explaining how I can test this locally).