### PR TITLE
Changed from uglifier to terser

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,23 +51,10 @@ and toggle features and settings using:
   simple_boolean_attributes: false  # Default: false
   compress_js_templates: false      # Default: false
   preserve_patterns:                # Default: (empty)
-  uglifier_args:                    # Default: (empty)
+  terser_args:                      # Default: (empty)
 </code></pre>
 
-js_args can be found in the the uglifier documentation at listed below
-
-Note: es6 has been implemented as experimental only via the upstream uglifier package.
-See https://github.com/lautis/uglifier for more information.
-
-To enable es6 syntax use:
-
-<pre><code>
-jekyll-minifier:
-  uglifier_args:
-    harmony: true
-
-</code></pre>
-
+js_args can be found in the [terser-ruby](https://github.com/ahorek/terser-ruby) documentation.
 
 # Like my stuff?
 

--- a/jekyll-minifier.gemspec
+++ b/jekyll-minifier.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |gem|
 
   gem.authors     = ["DigitalSparky"]
   gem.email       = ["matthew@spurrier.com.au"]
-  gem.description = %q{Jekyll Minifier using htmlcompressor for html, uglifier for js and css}
+  gem.description = %q{Jekyll Minifier using htmlcompressor for html, terser for js, and cssminify2 for css}
   gem.summary     = %q{Jekyll Minifier for html, css, and javascript}
   gem.homepage    = "http://github.com/digitalsparky/jekyll-minifier"
   gem.license     = "GPL-3.0"
@@ -27,7 +27,7 @@ Gem::Specification.new do |gem|
   end
 
   gem.add_dependency "jekyll", ">= 3.5"
-  gem.add_dependency "uglifier", "~> 4.1"
+  gem.add_dependency "terser", "~> 1.2.3"
   gem.add_dependency "htmlcompressor", "~> 0.4"
   gem.add_dependency "cssminify2", "~> 2.0"
   gem.add_dependency "json-minify", "~> 0.0.3"

--- a/lib/jekyll-minifier.rb
+++ b/lib/jekyll-minifier.rb
@@ -1,4 +1,4 @@
-require 'uglifier'
+require 'terser'
 require 'htmlcompressor'
 require 'cssminify2'
 require 'json/minify'
@@ -41,7 +41,7 @@ module Jekyll
         opts = @site.config['jekyll-minifier']
         if ( !opts.nil? )
           # Javascript Arguments
-          js_args[:uglifier_args] = Hash[opts['uglifier_args'].map{|(k,v)| [k.to_sym,v]}] if opts.has_key?('uglifier_args')
+          js_args[:terser_args] = Hash[opts['terser_args'].map{|(k,v)| [k.to_sym,v]}] if opts.has_key?('terser_args')
 
           # HTML Arguments
           html_args[:remove_spaces_inside_tags]   = opts['remove_spaces_inside_tags']  if opts.has_key?('remove_spaces_inside_tags')
@@ -69,10 +69,10 @@ module Jekyll
 
         html_args[:css_compressor]              = CSSminify2.new()
 
-        if ( !js_args[:uglifier_args].nil? )
-          html_args[:javascript_compressor]       = Uglifier.new(js_args[:uglifier_args])
+        if ( !js_args[:terser_args].nil? )
+          html_args[:javascript_compressor]       = ::Terser.new(js_args[:terser_args])
         else
-          html_args[:javascript_compressor]       = Uglifier.new()
+          html_args[:javascript_compressor]       = ::Terser.new()
         end
 
         compressor = HtmlCompressor::Compressor.new(html_args)
@@ -89,14 +89,14 @@ module Jekyll
         compress = true
         if ( !opts.nil? )
           compress                = opts['compress_javascript']                           if opts.has_key?('compress_javascript')
-          js_args[:uglifier_args] = Hash[opts['uglifier_args'].map{|(k,v)| [k.to_sym,v]}] if opts.has_key?('uglifier_args')
+          js_args[:terser_args] = Hash[opts['terser_args'].map{|(k,v)| [k.to_sym,v]}] if opts.has_key?('terser_args')
         end
 
         if ( compress )
-          if ( !js_args[:uglifier_args].nil? )
-            compressor = Uglifier.new(js_args[:uglifier_args])
+          if ( !js_args[:terser_args].nil? )
+            compressor = ::Terser.new(js_args[:terser_args])
           else
-            compressor = Uglifier.new()
+            compressor = ::Terser.new()
           end
 
           output_file(path, compressor.compile(content))


### PR DESCRIPTION
Changed from [uglifier](https://github.com/lautis/uglifier) to [terser](https://github.com/ahorek/terser-ruby) for better ES6 support.